### PR TITLE
Remove default image arg

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,12 +157,12 @@ jobs:
                 echo NAMD_OPTS= >> $GITHUB_ENV
                 echo GMX_OPTS= >> $GITHUB_ENV
                 echo LMP_OPTS= >> $GITHUB_ENV
-                echo RT_IMG="centos:7" >> $GITHUB_ENV
+                echo DOCKERFILE="Dockerfile.cpu" >> $GITHUB_ENV
               else
                 echo NAMD_OPTS="--with-cuda" >> $GITHUB_ENV
                 echo GMX_OPTS="-DGMX_GPU=CUDA" >> $GITHUB_ENV
                 echo LMP_OPTS="-DPKG_GPU=on -DGPU_API=cuda" >> $GITHUB_ENV
-                echo RT_IMG="nvidia/cuda:11.8.0-runtime-centos7" >> $GITHUB_ENV
+                echo DOCKERFILE="Dockerfile.gpu" >> $GITHUB_ENV
               fi
 
           - name: Build and push Docker image
@@ -170,8 +170,8 @@ jobs:
             with:
               context: ./docker/common
               push: false
+              file: ./docker/common/${{ env.DOCKERFILE }}
               build-args: |
                 NAMD_OPTS=${{ env.NAMD_OPTS }}
                 GMX_OPTS=${{ env.GMX_OPTS }}
                 LMP_OPTS=${{ env.LMP_OPTS }}
-                RT_IMG=${{ env.RT_IMG}}

--- a/.github/workflows/deploy_docker.yaml
+++ b/.github/workflows/deploy_docker.yaml
@@ -225,12 +225,12 @@ jobs:
             echo NAMD_OPTS= >> $GITHUB_ENV
             echo GMX_OPTS= >> $GITHUB_ENV
             echo LMP_OPTS= >> $GITHUB_ENV
-            echo RT_IMG="centos:7" >> $GITHUB_ENV
+            echo DOCKERFILE="Dockerfile.cpu" >> $GITHUB_ENV
           else
             echo NAMD_OPTS="--with-cuda" >> $GITHUB_ENV
             echo GMX_OPTS="-DGMX_GPU=CUDA" >> $GITHUB_ENV
             echo LMP_OPTS="-DPKG_GPU=on -DGPU_API=cuda" >> $GITHUB_ENV
-            echo RT_IMG="nvidia/cuda:11.8.0-runtime-centos7" >> $GITHUB_ENV
+            echo DOCKERFILE="Dockerfile.gpu" >> $GITHUB_ENV
           fi
 
       - name: Extract metadata (tags, labels) for Docker
@@ -243,6 +243,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./docker/common
+          file: ./docker/common/${{ env.DOCKERFILE }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}-${{ matrix.build }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -250,4 +251,3 @@ jobs:
             NAMD_OPTS=${{ env.NAMD_OPTS }}
             GMX_OPTS=${{ env.GMX_OPTS }}
             LMP_OPTS=${{ env.LMP_OPTS }}
-            RT_IMG=${{ env.RT_IMG }}

--- a/docker/common/Dockerfile
+++ b/docker/common/Dockerfile
@@ -1,4 +1,4 @@
-ARG RT_IMAGE=nvidia/cuda:11.8.0-runtime-centos7
+ARG RT_IMAGE
 # based on conda-forge linux image
 FROM condaforge/linux-anvil-cuda:11.8 AS build
 

--- a/docker/common/Dockerfile
+++ b/docker/common/Dockerfile
@@ -1,7 +1,9 @@
-ARG RT_IMAGE
+ARG RT_IMAGE=nvidia/cuda:11.8.0-runtime-centos7
 # based on conda-forge linux image
 FROM condaforge/linux-anvil-cuda:11.8 AS build
 
+# Docker weirdness, need the arg again for it to exist in build stage
+ARG RT_IMAGE
 ARG LMP_OPTS=""
 ARG GMX_OPTS=""
 ARG NAMD_OPTS=""

--- a/docker/common/Dockerfile.cpu
+++ b/docker/common/Dockerfile.cpu
@@ -1,0 +1,41 @@
+# based on conda-forge linux image
+FROM condaforge/linux-anvil-cuda:11.8 AS build
+
+ARG LMP_OPTS=""
+ARG GMX_OPTS=""
+ARG NAMD_OPTS=""
+
+COPY . .
+RUN source /opt/conda/etc/profile.d/conda.sh && conda env create --file env.yaml
+RUN source /opt/conda/etc/profile.d/conda.sh && conda activate env && ./install_lammps.sh "$LMP_OPTS"
+RUN source /opt/conda/etc/profile.d/conda.sh &&  conda activate env && ./install_gromacs.sh "$GMX_OPTS"
+RUN source /opt/conda/etc/profile.d/conda.sh &&  conda activate env && ./install_namd.sh "$NAMD_OPTS"
+
+# Delete the heavy environment but keep conda binaries
+RUN source /opt/conda/etc/profile.d/conda.sh && conda remove -n env --all -y
+RUN source /opt/conda/etc/profile.d/conda.sh && conda clean -a -y
+
+# CUDA toolkit is massive, so use a smaller image for the runtime
+FROM centos:7
+
+COPY . .
+COPY --from=build /opt/docker/bin/run_commands /opt/docker/bin/run_commands
+RUN /opt/docker/bin/run_commands
+
+COPY --from=build /opt/docker/bin/entrypoint /opt/docker/bin/entrypoint
+COPY --from=build /opt/docker/bin/entrypoint_source /opt/docker/bin/entrypoint_source
+
+# Create the new lightweight env
+RUN source /opt/conda/etc/profile.d/conda.sh && conda env create --file runtime_env.yaml
+
+COPY --from=build /opt/gromacs_build /opt/gromacs_build
+RUN ln -s /opt/gromacs_build/bin/gmx /bin/gmx
+
+COPY --from=build /opt/lammps_build /opt/lammps_build
+RUN ln -s /opt/lammps_build/bin/lmp /bin/lmp
+
+COPY --from=build /opt/namd-build /opt/namd-build
+RUN ln -s /opt/namd-build/namd3  /bin/namd3
+
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint" ]
+CMD [ "/bin/bash" ]

--- a/docker/common/Dockerfile.gpu
+++ b/docker/common/Dockerfile.gpu
@@ -1,9 +1,6 @@
-ARG RT_IMAGE=nvidia/cuda:11.8.0-runtime-centos7
 # based on conda-forge linux image
 FROM condaforge/linux-anvil-cuda:11.8 AS build
 
-# Docker weirdness, need the arg again for it to exist in build stage
-ARG RT_IMAGE
 ARG LMP_OPTS=""
 ARG GMX_OPTS=""
 ARG NAMD_OPTS=""
@@ -19,7 +16,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && conda remove -n env --all -y
 RUN source /opt/conda/etc/profile.d/conda.sh && conda clean -a -y
 
 # CUDA toolkit is massive, so use a smaller image for the runtime
-FROM ${RT_IMAGE} AS runtime
+FROM nvidia/cuda:11.8.0-runtime-centos7
 
 COPY . .
 COPY --from=build /opt/docker/bin/run_commands /opt/docker/bin/run_commands


### PR DESCRIPTION
Overriding the arg doesn't work in all versions of docker. Simplify by just having two dockerfiles selected with env arg.